### PR TITLE
Never cancel a Tests run on main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,15 @@ on:
 permissions:
   contents: read
 
-# A second push to the same branch makes the first run irrelevant.
+# A second push to the same branch makes the first run irrelevant — on a PR.
+# On main it does not: main is the release branch, and a tag is cut from
+# whatever commit is sitting there, so every commit on it needs a run of its
+# own. Merging five PRs in a row cancelled four of those runs, and because the
+# runs queue out of order the survivor was testing an *older* commit than the
+# head — main's actual head was never tested and nothing went red to say so.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   # Split from the Rust job so a TypeScript error reports in ~1 minute rather


### PR DESCRIPTION
`test.yml` sets `cancel-in-progress: true` keyed on `github.ref`. On pull requests that is exactly right. On `main` it means each merge kills the previous run — and because runs queue out of order, the survivor is not necessarily the head.

Merging the five Dependabot PRs showed it happening:

```
20:03:26  Tests  in_progress   9f22e97   ← older commit, survived
20:03:25  Tests  cancelled     9b65de3   ← main's head, killed
```

Main's head had no test run at all, and nothing went red — the failure mode is an *absence*, not a red tick, so it is easy to never notice. That matters because main is the release branch: the tag is cut from whatever commit sits there, and per CLAUDE.md pushing the tag is the point of no return.

```yaml
cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
```

PRs keep fast-cancel, which is where the CI minutes are actually saved; every commit on main gets a run of its own.

Verified the workflow still parses (`yaml.safe_load`). Worth remembering that CLAUDE.md records a case where a workflow passed both `yaml.safe_load` *and* actionlint and still failed to start, so this PR's own run is the real check — if it starts and goes green, the change is good.
